### PR TITLE
Add Telegram fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 
+# Telegram support is optional. If `python-telegram-bot` isn't installed,
+# notifications will be printed to the console.
+
 # Copy config & edit keys
 cp settings.toml.example settings.toml
 vim settings.toml

--- a/app/notifier.py
+++ b/app/notifier.py
@@ -4,10 +4,21 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from telegram import Bot
-
 logger = logging.getLogger(__name__)
 
+try:
+    from telegram import Bot  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    class Bot:
+        """Fallback bot when python-telegram-bot is missing."""
+
+        def __init__(self, *_, **__):
+            logger.warning(
+                "python-telegram-bot not installed; Telegram notifications disabled"
+            )
+
+        async def send_message(self, chat_id: str, text: str) -> None:  # noqa: D401
+            logger.info("[MOCK TG] %s: %s", chat_id, text)
 
 class TelegramNotifier:
     def __init__(self, token: str, chat_id: str) -> None:


### PR DESCRIPTION
## Summary
- add optional telegram notifier fallback if python-telegram-bot isn't installed
- mention optional telegram support in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683ad55782a08322801d33b386a097ef